### PR TITLE
Simplify html syntax

### DIFF
--- a/index.php
+++ b/index.php
@@ -127,10 +127,8 @@ final class Pasthis {
                         placeholder="Do not fill me!" />
                 <input type="submit" value="Send paste">
                 <span id="left">
-                <input type="checkbox" id="wrap" name="wrap">
-                <label for="wrap">wrap long lines</label>
-                <input type="checkbox" id="highlighting" name="highlighting">
-                <label for="highlighting">syntax highlighting</label>
+                <input type="checkbox" id="wrap" name="wrap"> wrap long lines<br />
+                <input type="checkbox" id="highlighting" name="highlighting"> syntax highlighting<br />
                 </span>
                 <textarea autofocus required name="p"></textarea>
             </form>'


### PR DESCRIPTION
Remove two lines after checkboxes and align it with text.