### PR TITLE
resources: Improve nginx rewrite rule

### DIFF
--- a/resources/nginx.conf
+++ b/resources/nginx.conf
@@ -10,6 +10,6 @@ location /resources {
 
 location / {
     if (!-e $request_filename){
-        rewrite "^([a-zA-Z0-9]{6}(@raw)?)$" /index.php?p=$1;
+        rewrite "^/*([a-zA-Z0-9]{6}(@raw)?)$" /index.php?p=$1 last;
     }
 }


### PR DESCRIPTION
This includes matching with an optional heading / (which was necessary to match
on my Debian Buster setup) and adds a trailing last keyword to indicate that
no further matching should be attempted in case of a match.

Signed-off-by: Paul Kocialkowski <paul.kocialkowski@bootlin.com>